### PR TITLE
Compatablity with older linux systems

### DIFF
--- a/R/nvimcom/src/nvimcom.c
+++ b/R/nvimcom/src/nvimcom.c
@@ -1,3 +1,6 @@
+#ifndef WIN32
+#define _POSIX_C_SOURCE 200112L
+#endif
 #include <R.h>  /* to include Rconfig.h */
 #include <Rinternals.h>
 #include <R_ext/Parse.h>


### PR DESCRIPTION
Code requires POSIX features (struct addrinfo/getaddrinfo) so the source must reflect this.